### PR TITLE
Replaces iconography for BG color on patch list for Success/Failure/Canceled

### DIFF
--- a/app/assets/stylesheets/projects.css.scss
+++ b/app/assets/stylesheets/projects.css.scss
@@ -21,17 +21,25 @@
 }
 
 .review-list {
+  -webkit-transition: background-color .15s linear;
+  -moz-transition: background-color .15s linear;
+  transition: background-color .15s linear;
   font-size: 15px;
   font-weight: normal;
   line-height: 18px;
-
+  display: block;
   border: 1px solid #e5e5e5;
   border-top: none;
   padding: 10px;
+  color: #333;
 
-  a {
+  &:hover {
     color: #333;
+    background-color: #f9f9f9;
     text-decoration: none;
+  }
+
+  .subject {
     font-weight: bold;
   }
 
@@ -43,10 +51,31 @@
   .target_branch {
     float: right;
   }
-}
 
-.review-list:hover {
-  background-color: #f9f9f9;
+  &.review-list--success {
+    background-color: #F1F8E9;
+
+    &:hover {
+      background-color: darken(#F1F8E9, 5%);
+    }
+  }
+
+  &.review-list--failure {
+    background-color: #FFEBEE;
+
+    &:hover {
+      background-color: darken(#FFEBEE, 5%);
+    }
+  }
+
+  &.review-list--canceled {
+    background-color: #EEEEEE;
+    opacity: .8;
+
+    &:hover {
+      background-color: darken(#EEEEEE, 5%);
+    }
+  }
 }
 
 #project_destroy {

--- a/app/helpers/merge_requests_helper.rb
+++ b/app/helpers/merge_requests_helper.rb
@@ -22,14 +22,18 @@ module MergeRequestsHelper
     "pending for #{time}"
   end
 
-  def patch_ci_icon(patch, only_cached = nil)
+  def patch_ci_status(patch, only_cached = nil)
     if patch.pass?
-      content_tag(:i, '', class: 'tipped fa fa-check ok', 'data-tip' => 'CI passed')
+      'review-list--success'
     elsif patch.canceled?
-      content_tag(:i, '', class: 'tipped fa fa-ban', 'data-tip' => 'CI canceled')
-    elsif only_cached && patch.failed?
-      content_tag(:i, '', class: 'tipped fa fa-remove fail', 'data-tip' => 'CI failed')
-    elsif only_cached
+      'review-list--canceled'
+    else only_cached && patch.failed?
+      'review-list--failure'
+    end
+  end
+
+  def patch_ci_icon(patch, only_cached = nil)
+    if only_cached
       return ''
     elsif @mr.nil? || !patch.project.gitlab_ci?
       content_tag(:i, '', class: 'tipped fa fa-ban', 'data-tip' => 'CI not available.')

--- a/app/views/merge_requests/_list.html.erb
+++ b/app/views/merge_requests/_list.html.erb
@@ -4,16 +4,21 @@
   <div class="review-list-container">
     <div class="review-list-header"><%= pluralize(mrs.count, *title) %></div>
     <%- mrs.each do |mr| %>
-      <div class="review-list">
+      <%= link_to project_merge_request_path(@project, mr), class: "review-list #{patch_ci_status(mr.patch, :only_cached)}" do %>
+
         <div class="subject">
-          <%= link_to mr.subject, project_merge_request_path(@project, mr) %>
+          <%= mr.subject %>
           <%= patch_ci_icon(mr.patch, :only_cached) %>
         </div>
-        <div class="summary">#<%= mr.id %> <%= merge_request_pending_since(mr) %>, opened by <%= mr.author.name %>, <span class="<%= mr.status %>"><%= mr.status.humanize %></span>
-        <span class="target_branch"><%= mr.target_branch %></span>
-        </div>
 
-      </div>
+        <div class="summary">
+          #<%= mr.id %> <%= merge_request_pending_since(mr) %>,
+          opened by <%= mr.author.name %>,
+          <span class="<%= mr.status %>"><%= mr.status.humanize %></span>
+
+          <span class="target_branch"><%= mr.target_branch %></span>
+        </div>
+      <% end %>
     <%- end %>
   </div>
 


### PR DESCRIPTION
All other icons were preserved.

![screen shot 2015-11-04 at 10 45 32](https://cloud.githubusercontent.com/assets/642737/10939728/8dbac078-82e2-11e5-9967-6962535623a2.png)
