### PR TITLE
Add hability to hide diffs

### DIFF
--- a/app/assets/javascripts/merge_requests.js
+++ b/app/assets/javascripts/merge_requests.js
@@ -86,3 +86,18 @@ function hide_comment_box(cancelLink) {
     $(tr).remove();
 }
 
+function toogle_merge_requests(){
+    var review_items = $('.code-review-item')
+    if(review_items.length > 0) {
+        review_items.find('.deleted').next('.code-review-container').slideUp(0)
+        review_items.find('.code-review-header').bind('click', function() {
+            var container = $(this).parents('.code-review-item').find('.code-review-container');
+            if(container.is(':visible')) {
+                container.slideUp();
+            } else {
+                container.slideDown();
+            }
+        })
+    }
+}
+

--- a/app/assets/stylesheets/merge_requests.css.scss
+++ b/app/assets/stylesheets/merge_requests.css.scss
@@ -25,9 +25,11 @@ pre.message {
   border-top: 1px solid #ccc;
   border-left: 1px solid #ccc;
   border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
   border-radius: 4px 4px 0px 0px;
   margin-top: 40px;
   clear: both;
+  cursor: pointer;
 
   .flag {
     font-weight: normal;
@@ -63,6 +65,7 @@ pre.message {
 .code-review-container {
   overflow-x: scroll;
   border: 1px solid #ccc;
+  border-top:none;
   border-radius: 0px 0px 4px 4px;
 }
 

--- a/app/helpers/merge_requests_helper.rb
+++ b/app/helpers/merge_requests_helper.rb
@@ -53,6 +53,21 @@ module MergeRequestsHelper
     end.join.html_safe
   end
 
+  def diff_file_status_class(file)
+    flags = []
+    if file.new?
+      flags.push 'new'
+      flags.push 'chmod-changed'
+    elsif file.deleted?
+      flags.push 'deleted'
+    elsif file.renamed?
+      flags.push 'renamed'
+    elsif file.chmod_changed?
+      flags.push 'chmod-changed'
+    end
+    flags.join(' ')
+  end
+
   def diff_file_status(file)
     flags = {}
     if file.new?

--- a/app/views/merge_requests/_diff.html.haml
+++ b/app/views/merge_requests/_diff.html.haml
@@ -5,21 +5,22 @@
       %a{ href: 'http://cyberelk.net/tim/software/patchutils/' } interdiff
 - else
   - @diff.each_file do |file|
-    .code-review-header
-      = file.label
-      = diff_file_status(file)
-    .code-review-container
-      %table.code-review
-        - file.each_change do |change, type, location, old_ln, new_ln|
-          %tr{ class: type, 'data-location' => location }
-            %td= old_ln
-            %td= new_ln
-            %td #{@disable_comments ? '' : '<div class="add-comment"></div>'.html_safe}#{change}
-          - if @comments.include?(location)
-            %tr.comment{ 'data-location' => location }
-              %td{ colspan: 2 }
-                = "\uf086 #{@comments[location].count}" if @comments[location].count > 1
-              %td
-                - @comments[location].each do |comment|
-                  = render partial: 'comment', locals: { comment: comment }
-                %input{ onclick: 'show_comment_box(this.parentElement.parentElement)', type: 'button', value: 'Reply' }/
+    .code-review-item
+      .code-review-header{ class: diff_file_status_class(file) }
+        = file.label
+        = diff_file_status(file)
+      .code-review-container
+        %table.code-review
+          - file.each_change do |change, type, location, old_ln, new_ln|
+            %tr{ class: type, 'data-location' => location }
+              %td= old_ln
+              %td= new_ln
+              %td #{@disable_comments ? '' : '<div class="add-comment"></div>'.html_safe}#{change}
+            - if @comments.include?(location)
+              %tr.comment{ 'data-location' => location }
+                %td{ colspan: 2 }
+                  = "\uf086 #{@comments[location].count}" if @comments[location].count > 1
+                %td
+                  - @comments[location].each do |comment|
+                    = render partial: 'comment', locals: { comment: comment }
+                  %input{ onclick: 'show_comment_box(this.parentElement.parentElement)', type: 'button', value: 'Reply' }/

--- a/app/views/merge_requests/show.html.haml
+++ b/app/views/merge_requests/show.html.haml
@@ -20,3 +20,6 @@
 - else
   %p
     %strong You found a bizarre merge request without patches.
+
+:javascript
+  toogle_merge_requests()


### PR DESCRIPTION
This commit introduces a behavior in merge request view. The user is able to toogle a diff and the diffs with status `deleted` will be hidden by default.