### PR TITLE
Open reviewit when the user clicks on notification

### DIFF
--- a/app/assets/javascripts/serviceworker.js.erb
+++ b/app/assets/javascripts/serviceworker.js.erb
@@ -1,5 +1,6 @@
 function receivePushNotification(event) {
   var data = JSON.parse(event.data && event.data.text());
+  self.lastURL = data['url']
   data['icon'] = "<%= asset_path 'favicon/android-chrome-144x144.png' %>";
   var title = data['title']
   delete data['title']
@@ -7,3 +8,22 @@ function receivePushNotification(event) {
 }
 
 self.addEventListener("push", receivePushNotification);
+
+self.addEventListener('notificationclick', function(event) {  
+  event.notification.close();
+  event.waitUntil(
+    clients.matchAll({  
+      type: "window"  
+    })
+    .then(function(clientList) {
+      for (var i = 0; i < clientList.length; i++) {  
+        var client = clientList[i];  
+        if ((client.url == self.lastURL || self.lastURL === '/') && 'focus' in client )  
+          return client.focus();  
+      }  
+      if (clients.openWindow) {
+        return clients.openWindow(self.lastURL);  
+      }
+    })
+  );
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,29 +34,29 @@ class User < ActiveRecord::Base
     webpush_endpoint.present? && webpush_p256dh.present? && webpush_auth.present?
   end
 
-  def self.send_webpush(users, title, body)
+  def self.send_webpush(users, title, body, url = '/')
     users.each do |user|
-      user.send_webpush_assync(title, body)
+      user.send_webpush_assync(title, body, url)
     end
   end
 
-  def send_webpush_assync(title, body)
+  def send_webpush_assync(title, body, url = '/')
     return unless webpush_notification_enabled?
 
     Thread.new do
       begin
-        send_webpush(title, body)
+        send_webpush(title, body, url)
       ensure
         ActiveRecord::Base.connection.close
       end
     end
   end
 
-  def send_webpush(title, body)
+  def send_webpush(title, body, url = '/')
     return unless webpush_notification_enabled?
 
     Webpush.payload_send(
-      message: { title: title, body: body, tag: 'reviewit' }.to_json,
+      message: { title: title, body: body, tag: 'reviewit', url: url }.to_json,
       endpoint: webpush_endpoint,
       p256dh: webpush_p256dh,
       auth: webpush_auth,


### PR DESCRIPTION
This commit introduces a listener to the “notificationClick” event and searches for a open tab with that url, if there’s no open tabs that matches the notifications url the listener will open a new one.

There's a problem with this implementation: if the user receives two or more notifications the listener will open the url of the last notification. We can improve it later.